### PR TITLE
Add :micros keyword to *features*

### DIFF
--- a/micros.asd
+++ b/micros.asd
@@ -2,6 +2,8 @@
   :depends-on ()
   :version "0.0.0"
   :serial t
+  :perform (load-op :after (o c)
+                    (uiop:symbol-call :micros :before-init))
   :components ((:file "packages")
                (:module "sbcl"
                 :pathname "backend"

--- a/micros.lisp
+++ b/micros.lisp
@@ -83,6 +83,10 @@ include some arbitrary initial value like NIL."
 ;;; simple indirection. The interface is more CLish than the Emacs
 ;;; Lisp one.
 
+(defun before-init ()
+  "Is run when the system is loaded, see micros.asd"
+  (pushnew :micros *features*))
+
 (defmacro add-hook (place function)
   "Add FUNCTION to the list of values on PLACE."
   `(pushnew ,function ,place))


### PR DESCRIPTION
Add the keyword `:micros` to `*features*`
Swank adds a keyword `:swank` to `*features*` in a similar way.
This is useful when defining behavior that should only load when developing from lem, or developing in general.
e.g:
```lisp
#+micros
(defun development-helper ())
```