### PR TITLE
fix passing a character to %utf8-encode

### DIFF
--- a/backend/backend.lisp
+++ b/backend/backend.lisp
@@ -285,7 +285,7 @@ form suitable for testing with #+."
                (t start)))
         ((<= code #x7ff) (utf8-encode-aux code buffer start end 2))
         ((<= #xd800 code #xdfff)
-         (%utf8-encode (code-char #xFFFD) ;; Replacement_Character
+         (%utf8-encode #xFFFD ;; Replacement_Character
                        buffer start end))
         ((<= code #xffff) (utf8-encode-aux code buffer start end 3))
         ((<= code #x1fffff) (utf8-encode-aux code buffer start end 4))


### PR DESCRIPTION
I was getting an SBCL compiler warning that led me to this, which I noticed that upstream slime also fixed in https://github.com/slime/slime/commit/f1f9991c697de2ecf0f3c1f0d43175ac35cb713c.