### PR TITLE
Add ability to use local unix socket in sbcl

### DIFF
--- a/backend/backend.lisp
+++ b/backend/backend.lisp
@@ -344,6 +344,10 @@ form suitable for testing with #+."
   "Create a listening TCP socket on interface HOST and port PORT.
 BACKLOG queue length for incoming connections.")
 
+(definterface create-local-socket (socket-path &key backlog)
+  "Create a listening local (currently: UNIX domain) socket at SOCKET-PATH.
+BACKLOG queue length for incomming connections.")
+
 (definterface local-port (socket)
   "Return the local port number of SOCKET.")
 

--- a/backend/sbcl.lisp
+++ b/backend/sbcl.lisp
@@ -134,6 +134,19 @@
     (sb-bsd-sockets:socket-listen socket (or backlog 5))
     socket))
 
+;; Local socket on unix
+
+#+unix
+(defimplementation create-local-socket (socket-path &key backlog)
+  (handler-case
+      (sb-posix:unlink socket-path)
+    ;; We don't care if it doesn't exist yet
+    (sb-posix:syscall-error ()))
+  (let ((socket (make-instance 'sb-bsd-sockets:local-socket :type :stream)))
+    (sb-bsd-sockets:socket-bind socket socket-path)
+    (sb-bsd-sockets:socket-listen socket (or backlog 5))
+    socket))
+
 (defimplementation local-port (socket)
   (nth-value 1 (sb-bsd-sockets:socket-name socket)))
 

--- a/packages.lisp
+++ b/packages.lisp
@@ -135,6 +135,7 @@
   (:export #:startup-multiprocessing
            #:start-server
            #:create-server
+           #:create-server-unix
            #:stop-server
            #:restart-server
            #:ed-in-emacs


### PR DESCRIPTION
I found [this](https://github.com/slime/slime/pull/635) recently and thought it would be nice to be able to use local sockets in Lem.

This pull request adds `create-server-unix` which starts swank on a local unix socket.

Currently it is only available in SBCL. But it should not be too hard to port to other lisps, I hope.
